### PR TITLE
Publish Windows binaries to Release

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.php]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,22 @@ jobs:
         shell: cmd
     strategy:
       matrix:
-          version: ['8.0', '8.1']
-          arch: [x64, x86]
-          ts: [ts]
-    runs-on: windows-2019
+        version: ['8.3']
+        arch: [x64]
+        ts: [ts]
+    runs-on: windows-latest
     steps:
       - name: Checkout xmlrpc
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+      - name: Extract Version
+        shell: powershell
+        run: |
+          chcp 65001
+          $r = Select-String -Path php_xmlrpc.h -Pattern 'PHP_XMLRPC_VERSION\s+"(.*)"'
+          $s = $r.Matches[0].Groups[1]
+          echo "$s"
+          $extension_version = 'EXTENSION_VERSION=' + $s
+          echo $extension_version >> $env:GITHUB_ENV
       - name: Setup PHP
         id: setup-php
         uses: cmb69/setup-php-sdk@v0.3
@@ -36,3 +45,49 @@ jobs:
         run: nmake
       - name: test
         run: nmake test TESTS="-g FAIL,SKIP --show-diff tests"
+      - name: Define Module Env
+        shell: powershell
+        run: |
+          chcp 65001
+
+          $dir = (Get-Location).Path + '\'
+          if ('x64' -eq '${{matrix.arch}}') { $dir = $dir + 'x64\' }
+          $dir = $dir + 'Release'
+          if ('ts' -eq '${{matrix.ts}}') { $dir = $dir + '_TS' }
+
+          $artifact_name = 'php_xmlrpc-${{env.EXTENSION_VERSION}}-${{matrix.version}}'
+
+          if ('ts' -eq '${{matrix.ts}}') { $artifact_name = $artifact_name + '-ts' }
+          if ('nts' -eq '${{matrix.ts}}') { $artifact_name = $artifact_name + '-nts' }
+
+          if ('7.2' -eq '${{matrix.version}}') { $artifact_name = $artifact_name + '-vc15' }
+          if ('7.3' -eq '${{matrix.version}}') { $artifact_name = $artifact_name + '-vc15' }
+          if ('7.4' -eq '${{matrix.version}}') { $artifact_name = $artifact_name + '-vc15' }
+          if ('8.0' -eq '${{matrix.version}}') { $artifact_name = $artifact_name + '-vs16' }
+          if ('8.1' -eq '${{matrix.version}}') { $artifact_name = $artifact_name + '-vs16' }
+          if ('8.2' -eq '${{matrix.version}}') { $artifact_name = $artifact_name + '-vs16' }
+          if ('8.3' -eq '${{matrix.version}}') { $artifact_name = $artifact_name + '-vs16' }
+
+          if ('x64' -eq '${{matrix.arch}}') { $artifact_name = $artifact_name + '-x64' }
+          if ('x86' -eq '${{matrix.arch}}') { $artifact_name = $artifact_name + '-x86' }
+
+          $extension_artifact_name = "ARTIFACT_NAME=" + $artifact_name
+          echo $extension_artifact_name >> $env:GITHUB_ENV
+
+          $from = $dir + '\php_xmlrpc.dll'
+          $to = $from + ".zip"
+          Compress-Archive $from $to
+          $extension_artifact = "ARTIFACT=" + $from
+          echo $extension_artifact >> $env:GITHUB_ENV
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+            name: ${{env.ARTIFACT_NAME}}
+            path: ${{env.ARTIFACT}}
+      - name: Publish Binaries to Release
+        if: ${{ startsWith(github.ref, 'refs/tags') }}
+        uses: svenstaro/upload-release-action@v2
+        with:
+            asset_name: ${{env.ARTIFACT_NAME}}.zip
+            file: ${{env.ARTIFACT}}.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
         shell: cmd
     strategy:
       matrix:
-        version: ['8.3']
-        arch: [x64]
-        ts: [ts]
+        version: ['8.0', '8.1', '8.2', '8.3']
+        arch: [x64, x86]
+        ts: [ts, nts]
     runs-on: windows-latest
     steps:
       - name: Checkout xmlrpc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,12 @@ jobs:
           echo $extension_version >> $env:GITHUB_ENV
       - name: Setup PHP
         id: setup-php
-        uses: cmb69/setup-php-sdk@v0.3
+        uses: php/setup-php-sdk@v0.8
         with:
-          version: ${{matrix.version}}
-          arch: ${{matrix.arch}}
-          ts: ${{matrix.ts}}
-          deps: libiconv, libxml2
-      - run: tree /a /f deps/include
+            version: ${{matrix.version}}
+            arch: ${{matrix.arch}}
+            ts: ${{matrix.ts}}
+            deps: "libiconv,libxml2"
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         shell: cmd
     strategy:
       matrix:
-        version: ['8.0', '8.1', '8.2', '8.3']
+        version: ['8.0', '8.1', '8.2', '8.3', '8.4']
         arch: [x64, x86]
         ts: [ts, nts]
     runs-on: windows-latest
@@ -43,7 +43,7 @@ jobs:
       - name: make
         run: nmake
       - name: test
-        run: nmake test TESTS="-g FAIL,SKIP --show-diff tests"
+        run: nmake test TESTS="--show-diff tests"
       - name: Define Module Env
         shell: powershell
         run: |
@@ -66,6 +66,7 @@ jobs:
           if ('8.1' -eq '${{matrix.version}}') { $artifact_name = $artifact_name + '-vs16' }
           if ('8.2' -eq '${{matrix.version}}') { $artifact_name = $artifact_name + '-vs16' }
           if ('8.3' -eq '${{matrix.version}}') { $artifact_name = $artifact_name + '-vs16' }
+          if ('8.4' -eq '${{matrix.version}}') { $artifact_name = $artifact_name + '-vs17' }
 
           if ('x64' -eq '${{matrix.arch}}') { $artifact_name = $artifact_name + '-x64' }
           if ('x86' -eq '${{matrix.arch}}') { $artifact_name = $artifact_name + '-x86' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           echo $extension_version >> $env:GITHUB_ENV
       - name: Setup PHP
         id: setup-php
-        uses: php/setup-php-sdk@v0.8
+        uses: php/setup-php-sdk@v0.10
         with:
             version: ${{matrix.version}}
             arch: ${{matrix.arch}}


### PR DESCRIPTION
Added four steps in "Build and Test on Windows" workflow:
- Extract version
- Define Module Env
- Upload artifacts
- Publish Binaries to Release

Here you can see what a Release would look like:
https://github.com/alphp/pecl-networking-xmlrpc/releases/tag/1.0.0RC3-1
![image](https://github.com/php/pecl-networking-xmlrpc/assets/8992091/7fa5f15a-05d3-4260-96f5-5568468e3557)

