### PR TITLE
Update Windows CI to be compatible with php/pie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,37 +1,52 @@
 name: Build and Test
-on: [push, pull_request]
+
+on:
+  push:
+    branches: ['**']
+    tags: ['*']
+  pull_request:
+
+permissions:
+  contents: write
+
 jobs:
-  windows:
-    defaults:
-      run:
-        shell: cmd
-    strategy:
-      matrix:
-          version: ['8.0', '8.1', '8.2', '8.3']
-          arch: [x64, x86]
-          ts: [ts]
-    runs-on: windows-2019
+  get-extension-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.extension-matrix.outputs.matrix }}
     steps:
-      - name: Checkout xmlrpc
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        id: setup-php
-        uses: php/setup-php-sdk@v0.8
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Get the extension matrix
+        id: extension-matrix
+        uses: php/php-windows-builder/extension-matrix@v1
+
+  build:
+    needs: get-extension-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-extension-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build the extension
+        uses: php/php-windows-builder/extension@v1
         with:
-          version: ${{matrix.version}}
-          arch: ${{matrix.arch}}
-          ts: ${{matrix.ts}}
-          deps: libiconv, libxml2
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1
+          php-version: ${{ matrix.php-version }}
+          arch: ${{ matrix.arch }}
+          ts: ${{ matrix.ts }}
+          libs: libiconv, libxml2
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - name: Upload artifact to the release
+        uses: php/php-windows-builder/release@v1
         with:
-          arch: ${{matrix.arch}}
-          toolset: ${{steps.setup-php.outputs.toolset}}
-      - name: phpize
-        run: phpize
-      - name: configure
-        run: configure --with-xmlrpc --with-prefix=${{steps.setup-php.outputs.prefix}}
-      - name: make
-        run: nmake
-      - name: test
-        run: nmake test TESTS="--show-diff tests"
+          release: ${{ github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "pecl/xmlrpc",
+  "type": "php-ext",
+  "license": "PHP-3.01",
+  "description": "Functions to write XML-RPC servers and clients",
+  "require": {
+    "php": ">=8.0.0"
+  },
+  "php-ext": {
+    "extension-name": "xmlrpc",
+    "configure-options": [
+      {
+        "name": "with-xmlrpc",
+        "description": "XMLRPC-EPI support",
+        "needs-value": false
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR switches the Windows CI to use [php/php-windows-builder](https://github.com/php/php-windows-builder).

It should run on a new tag push and create a release for it with the builds that are compatible with php/pie.